### PR TITLE
Continue to build commonjs until immutable v6

### DIFF
--- a/packages/devtools/demo/demo.js
+++ b/packages/devtools/demo/demo.js
@@ -1,5 +1,5 @@
 import * as Immutable from 'immutable';
-import installDevTools from '../dist/index.js';
+import installDevTools from '../dist/index.mjs';
 
 var MyRecord = Immutable.Record(
   {

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -5,16 +5,19 @@
   "description": "Chrome Dev Tools formatter for the Immutable JS library",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs",
       "types": "./dist/index.d.ts"
     }
   },
+  "main": "dist/index.cjs",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
     "build:types": "tsc",
-    "build:module": "rollup -c",
+    "build:module": "rm -rf dist; rollup -c",
     "build": "yarn run build:types && yarn run build:module",
     "lint:types": "tsc --noEmit",
     "lint": "yarn run lint:types",

--- a/packages/devtools/rollup.config.js
+++ b/packages/devtools/rollup.config.js
@@ -29,10 +29,16 @@ function injectDemoSource() {
 const config = [
   {
     input: 'src/index.ts',
-    output: {
-      dir: 'dist',
-      format: 'es',
-    },
+    output: [
+      {
+        file: 'dist/index.mjs',
+        format: 'es',
+      },
+      {
+        file: 'dist/index.cjs',
+        format: 'cjs',
+      },
+    ],
     plugins: [
       babel({
         babelHelpers: 'bundled',

--- a/packages/devtools/test.js
+++ b/packages/devtools/test.js
@@ -3,7 +3,7 @@
 import Immutable4 from 'immutable';
 import Immutable3 from 'immutable3';
 
-import installDevTools from './dist/index.js';
+import installDevTools from './dist/index.mjs';
 installDevTools(Immutable4);
 
 console.log('Testing with Immutable 4');


### PR DESCRIPTION
jest does not work on the main branch for now, possibly babel not replaced by buble for now: https://github.com/immutable-js/immutable-js/actions/runs/15347902365/job/43188396235?pr=2111

Let's continue to publish commonjs for now. 